### PR TITLE
Rollback version to 1.2.1 to release for Rails 5

### DIFF
--- a/lib/dm-active_model/version.rb
+++ b/lib/dm-active_model/version.rb
@@ -1,5 +1,5 @@
 module DataMapper
   module ActiveModel
-    VERSION = '1.3.0.beta'
+    VERSION = '1.2.1'
   end
 end


### PR DESCRIPTION
Rollback version to 1.2.1 from 1.3.0.beta
